### PR TITLE
Remove Inflex

### DIFF
--- a/lib/live_view_native_swift_ui/modifiers.ex
+++ b/lib/live_view_native_swift_ui/modifiers.ex
@@ -9,11 +9,8 @@ defmodule LiveViewNativeSwiftUi.Modifiers do
     :tint
   ]
 
-  def encode_key(key), do: Inflex.camelize("#{key}", :lower)
-
   def encode_map(%{} = map) do
     map
-    |> Enum.map(fn {key, value} -> {encode_key(key), value} end)
     |> Enum.into(%{})
   end
 
@@ -30,7 +27,7 @@ defmodule LiveViewNativeSwiftUi.Modifiers do
               modifier =
                 props
                 |> Modifiers.encode_map()
-                |> Map.put(:type, Modifiers.encode_key(key))
+                |> Map.put(:type, key)
 
               acc ++ [modifier]
 

--- a/mix.exs
+++ b/mix.exs
@@ -25,7 +25,6 @@ defmodule LiveViewNativeSwiftUi.MixProject do
     [
       {:jason, "~> 1.2"},
       {:ex_doc, ">= 0.0.0", only: :dev, runtime: false},
-      {:inflex, "~> 2.0.0"},
       {:live_view_native_platform, "~> 0.0.2"}
     ]
   end


### PR DESCRIPTION
Related to https://github.com/liveviewnative/liveview-client-swiftui/pull/148

Removes the dependency on `Inflex` and uses the original snake case names as the modifier `type`.