### PR TITLE
Avoid `AnyView` in modifiers

### DIFF
--- a/lib/live_view_native_swift_ui/modifiers.ex
+++ b/lib/live_view_native_swift_ui/modifiers.ex
@@ -5,7 +5,9 @@ defmodule LiveViewNativeSwiftUi.Modifiers do
   ]
 
   def encode_map(%{} = map) do
+    # JSON-encode each value
     Enum.into(map, %{})
+      |> Map.new(fn term -> put_elem(term, 1, Jason.encode!(elem(term, 1))) end)
   end
 
   defimpl LiveViewNativePlatform.Modifiers do


### PR DESCRIPTION
Companion PR to https://github.com/liveviewnative/liveview-client-swiftui/pull/161, encodes each value in the modifier map to JSON as expected in that PR.